### PR TITLE
Remove redundant linking of library

### DIFF
--- a/migrations/1_deploy_contract.js
+++ b/migrations/1_deploy_contract.js
@@ -1,8 +1,5 @@
-const ProtobufLib = artifacts.require("ProtobufLib");
 const TestFixture = artifacts.require("TestFixture");
 
 module.exports = function (deployer) {
-  deployer.deploy(ProtobufLib);
-  deployer.link(ProtobufLib, TestFixture);
   deployer.deploy(TestFixture);
 };


### PR DESCRIPTION
Library internal functions don't need to be linked since they're compiled in.