### PR TITLE
Decode enums as int32

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npm run test
 | `fixed64`           |   ✔️   |   ❌   |
 | `sfixed64`          |   ✔️   |   ❌   |
 | `bool`              |   ✔️   |   ❌   |
-| enum                |   ✔️   |   ❌   |
+| enum                |   ❓   |   ❌   |
 | `string`            |   ✔️   |   ❌   |
 | `bytes`             |   ✔️   |   ❌   |
 | embedded messages   |   ✔️   |   ❌   |

--- a/contracts/ProtobufLib.sol
+++ b/contracts/ProtobufLib.sol
@@ -190,8 +190,8 @@ library ProtobufLib {
     /// @param buf Buffer
     /// @return New position
     /// @return Decoded enum as raw int
-    function decode_enum(uint256 p, bytes memory buf) internal pure returns (uint256, uint64) {
-        return decode_uint64(p, buf);
+    function decode_enum(uint256 p, bytes memory buf) internal pure returns (uint256, int32) {
+        return decode_int32(p, buf);
     }
 
     /// @notice Decode fixed 64-bit int.

--- a/contracts/TestFixture.sol
+++ b/contracts/TestFixture.sol
@@ -49,7 +49,7 @@ contract TestFixture {
         return ProtobufLib.decode_bool(p, buf);
     }
 
-    function decode_enum(uint256 p, bytes memory buf) public returns (uint256, uint64) {
+    function decode_enum(uint256 p, bytes memory buf) public returns (uint256, int32) {
         return ProtobufLib.decode_enum(p, buf);
     }
 


### PR DESCRIPTION
Enums use `int32` as their underlying data format: https://developers.google.com/protocol-buffers/docs/proto3#enum