### PR TITLE
Refactor functions to not revert

### DIFF
--- a/contracts/ProtobufLib.sol
+++ b/contracts/ProtobufLib.sol
@@ -278,26 +278,26 @@ library ProtobufLib {
     /// @param p Position
     /// @param buf Buffer
     /// @return New position
-    /// @return Field bytes
-    function decode_length_delimited(uint256 p, bytes memory buf) internal pure returns (uint256, bytes memory) {
+    /// @return Size in bytes
+    function decode_length_delimited(uint256 p, bytes memory buf) internal pure returns (uint256, uint64) {
         // Length-delimited fields begin with a varint of the number of bytes that follow
         (uint256 pos, uint64 size) = decode_varint(p, buf);
 
-        bytes memory field = new bytes(size);
-        for (uint256 i = 0; i < size; i++) {
-            field[i] = buf[pos + i];
-        }
-
-        return (pos + size, field);
+        return (pos, size);
     }
 
     /// @notice Decode string.
     /// @param p Position
     /// @param buf Buffer
     /// @return New position
-    /// @return Decoded string
+    /// @return Size in bytes
     function decode_string(uint256 p, bytes memory buf) internal pure returns (uint256, string memory) {
-        (uint256 pos, bytes memory field) = decode_length_delimited(p, buf);
+        (uint256 pos, uint64 size) = decode_length_delimited(p, buf);
+
+        bytes memory field = new bytes(size);
+        for (uint256 i = 0; i < size; i++) {
+            field[i] = buf[pos + i];
+        }
 
         return (pos, string(field));
     }
@@ -306,33 +306,26 @@ library ProtobufLib {
     /// @param p Position
     /// @param buf Buffer
     /// @return New position
-    /// @return Field bytes
-    function decode_bytes(uint256 p, bytes memory buf) internal pure returns (uint256, bytes memory) {
-        (uint256 pos, bytes memory field) = decode_length_delimited(p, buf);
-
-        return (pos, field);
+    /// @return Size in bytes
+    function decode_bytes(uint256 p, bytes memory buf) internal pure returns (uint256, uint64) {
+        return decode_length_delimited(p, buf);
     }
 
     /// @notice Decode embedded message.
     /// @param p Position
     /// @param buf Buffer
     /// @return New position
-    /// @return Field bytes
-    function decode_embedded_message(uint256 p, bytes memory buf) internal pure returns (uint256, bytes memory) {
-        (uint256 pos, bytes memory field) = decode_length_delimited(p, buf);
-
-        return (pos, field);
+    /// @return Size in bytes
+    function decode_embedded_message(uint256 p, bytes memory buf) internal pure returns (uint256, uint64) {
+        return decode_length_delimited(p, buf);
     }
 
     /// @notice Decode packed repeated field.
     /// @param p Position
     /// @param buf Buffer
-    /// @return New position
-    /// @return Field bytes
-    function decode_packed_repeated(uint256 p, bytes memory buf) internal pure returns (uint256, bytes memory) {
-        (uint256 pos, bytes memory field) = decode_length_delimited(p, buf);
-
-        return (pos, field);
+    /// @return Size in bytes
+    function decode_packed_repeated(uint256 p, bytes memory buf) internal pure returns (uint256, uint64) {
+        return decode_length_delimited(p, buf);
     }
 
     ////////////////////////////////////

--- a/contracts/ProtobufLib.sol
+++ b/contracts/ProtobufLib.sol
@@ -505,11 +505,7 @@ library ProtobufLib {
     /// @return Success
     /// @return New position
     /// @return Size in bytes
-    function decode_string(
-        bool,
-        uint256 p,
-        bytes memory buf
-    )
+    function decode_string(uint256 p, bytes memory buf)
         internal
         pure
         returns (

--- a/contracts/ProtobufLib.sol
+++ b/contracts/ProtobufLib.sol
@@ -73,8 +73,12 @@ library ProtobufLib {
         uint64 val;
         uint256 i;
 
-        // TODO add a check for array bounds
         for (i = 0; i < MAX_VARINT_BYTES; i++) {
+            // Check that index is within bounds
+            if (i + p >= buf.length) {
+                return (false, p, 0);
+            }
+
             // Get byte at offset
             uint8 b = uint8(buf[p + i]);
 
@@ -340,7 +344,11 @@ library ProtobufLib {
     {
         uint64 val;
 
-        // TODO add a check for array bounds
+        // Check that index is within bounds
+        if (8 + p > buf.length) {
+            return (false, p, 0);
+        }
+
         for (uint256 i = 0; i < 8; i++) {
             uint8 b = uint8(buf[p + i]);
 
@@ -414,7 +422,11 @@ library ProtobufLib {
     {
         uint32 val;
 
-        // TODO add a check for array bounds
+        // Check that index is within bounds
+        if (4 + p > buf.length) {
+            return (false, p, 0);
+        }
+
         for (uint256 i = 0; i < 4; i++) {
             uint8 b = uint8(buf[p + i]);
 
@@ -492,7 +504,8 @@ library ProtobufLib {
             return (false, pos, 0);
         }
 
-        if (size > buf.length - pos) {
+        // Check that index is within bounds
+        if (size + pos > buf.length) {
             return (false, pos, 0);
         }
 
@@ -519,7 +532,6 @@ library ProtobufLib {
             return (false, pos, "");
         }
 
-        // TODO add a check for array bounds
         bytes memory field = new bytes(size);
         for (uint256 i = 0; i < size; i++) {
             field[i] = buf[pos + i];

--- a/contracts/ProtobufLib.sol
+++ b/contracts/ProtobufLib.sol
@@ -525,14 +525,14 @@ library ProtobufLib {
             field[i] = buf[pos + i];
         }
 
-        return (true, pos, string(field));
+        return (true, pos + size, string(field));
     }
 
     /// @notice Decode bytes array.
     /// @param p Position
     /// @param buf Buffer
     /// @return Success
-    /// @return New position
+    /// @return New position (after size)
     /// @return Size in bytes
     function decode_bytes(uint256 p, bytes memory buf)
         internal
@@ -550,7 +550,7 @@ library ProtobufLib {
     /// @param p Position
     /// @param buf Buffer
     /// @return Success
-    /// @return New position
+    /// @return New position (after size)
     /// @return Size in bytes
     function decode_embedded_message(uint256 p, bytes memory buf)
         internal
@@ -568,6 +568,7 @@ library ProtobufLib {
     /// @param p Position
     /// @param buf Buffer
     /// @return Success
+    /// @return New position (after size)
     /// @return Size in bytes
     function decode_packed_repeated(uint256 p, bytes memory buf)
         internal

--- a/contracts/TestFixture.sol
+++ b/contracts/TestFixture.sol
@@ -9,6 +9,7 @@ contract TestFixture {
     function decode_key(uint256 p, bytes memory buf)
         public
         returns (
+            bool,
             uint256,
             uint64,
             ProtobufLib.WireType
@@ -17,83 +18,223 @@ contract TestFixture {
         return ProtobufLib.decode_key(p, buf);
     }
 
-    function decode_varint(uint256 p, bytes memory buf) public returns (uint256, uint64) {
+    function decode_varint(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            uint64
+        )
+    {
         return ProtobufLib.decode_varint(p, buf);
     }
 
-    function decode_int32(uint256 p, bytes memory buf) public returns (uint256, int32) {
+    function decode_int32(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            int32
+        )
+    {
         return ProtobufLib.decode_int32(p, buf);
     }
 
-    function decode_int64(uint256 p, bytes memory buf) public returns (uint256, int64) {
+    function decode_int64(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            int64
+        )
+    {
         return ProtobufLib.decode_int64(p, buf);
     }
 
-    function decode_uint32(uint256 p, bytes memory buf) public returns (uint256, uint32) {
+    function decode_uint32(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            uint32
+        )
+    {
         return ProtobufLib.decode_uint32(p, buf);
     }
 
-    function decode_uint64(uint256 p, bytes memory buf) public returns (uint256, uint64) {
+    function decode_uint64(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            uint64
+        )
+    {
         return ProtobufLib.decode_uint64(p, buf);
     }
 
-    function decode_sint32(uint256 p, bytes memory buf) public returns (uint256, int32) {
+    function decode_sint32(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            int32
+        )
+    {
         return ProtobufLib.decode_sint32(p, buf);
     }
 
-    function decode_sint64(uint256 p, bytes memory buf) public returns (uint256, int64) {
+    function decode_sint64(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            int64
+        )
+    {
         return ProtobufLib.decode_sint64(p, buf);
     }
 
-    function decode_bool(uint256 p, bytes memory buf) public returns (uint256, bool) {
+    function decode_bool(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            bool
+        )
+    {
         return ProtobufLib.decode_bool(p, buf);
     }
 
-    function decode_enum(uint256 p, bytes memory buf) public returns (uint256, int32) {
+    function decode_enum(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            int32
+        )
+    {
         return ProtobufLib.decode_enum(p, buf);
     }
 
-    function decode_bits64(uint256 p, bytes memory buf) public returns (uint256, uint64) {
+    function decode_bits64(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            uint64
+        )
+    {
         return ProtobufLib.decode_bits64(p, buf);
     }
 
-    function decode_fixed64(uint256 p, bytes memory buf) public returns (uint256, uint64) {
+    function decode_fixed64(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            uint64
+        )
+    {
         return ProtobufLib.decode_fixed64(p, buf);
     }
 
-    function decode_sfixed64(uint256 p, bytes memory buf) public returns (uint256, int64) {
+    function decode_sfixed64(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            int64
+        )
+    {
         return ProtobufLib.decode_sfixed64(p, buf);
     }
 
-    function decode_bits32(uint256 p, bytes memory buf) public returns (uint256, uint32) {
+    function decode_bits32(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            uint32
+        )
+    {
         return ProtobufLib.decode_bits32(p, buf);
     }
 
-    function decode_fixed32(uint256 p, bytes memory buf) public returns (uint256, uint32) {
+    function decode_fixed32(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            uint32
+        )
+    {
         return ProtobufLib.decode_fixed32(p, buf);
     }
 
-    function decode_sfixed32(uint256 p, bytes memory buf) public returns (uint256, int32) {
+    function decode_sfixed32(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            int32
+        )
+    {
         return ProtobufLib.decode_sfixed32(p, buf);
     }
 
-    function decode_length_delimited(uint256 p, bytes memory buf) public returns (uint256, bytes memory) {
+    function decode_length_delimited(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            uint64
+        )
+    {
         return ProtobufLib.decode_length_delimited(p, buf);
     }
 
-    function decode_string(uint256 p, bytes memory buf) public returns (uint256, string memory) {
+    function decode_string(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            string memory
+        )
+    {
         return ProtobufLib.decode_string(p, buf);
     }
 
-    function decode_bytes(uint256 p, bytes memory buf) public returns (uint256, bytes memory) {
+    function decode_bytes(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            uint64
+        )
+    {
         return ProtobufLib.decode_bytes(p, buf);
     }
 
-    function decode_embedded_message(uint256 p, bytes memory buf) public returns (uint256, bytes memory) {
+    function decode_embedded_message(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            uint64
+        )
+    {
         return ProtobufLib.decode_embedded_message(p, buf);
     }
 
-    function decode_packed_repeated(uint256 p, bytes memory buf) public returns (uint256, bytes memory) {
+    function decode_packed_repeated(uint256 p, bytes memory buf)
+        public
+        returns (
+            bool,
+            uint256,
+            uint64
+        )
+    {
         return ProtobufLib.decode_packed_repeated(p, buf);
     }
 

--- a/test/TestFixture.js
+++ b/test/TestFixture.js
@@ -38,7 +38,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_varint.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, 3);
       assert.equal(val, 300);
 
@@ -53,7 +54,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_key.call(0, "0x" + encoded);
-      const { 0: pos, 1: field, 2: type } = result;
+      const { 0: success, 1: pos, 2: field, 3: type } = result;
+      assert.equal(success, true);
       assert.equal(pos, 1);
       assert.equal(field, 2);
       assert.equal(type, 0);
@@ -71,7 +73,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_int32.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -88,7 +91,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_int32.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -105,7 +109,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_int32.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -122,7 +127,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_int32.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -139,7 +145,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_uint32.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -156,7 +163,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_uint32.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -172,10 +180,9 @@ contract("TestFixture", async (accounts) => {
       const message = Message.create({ field: v });
       const encoded = Message.encode(message).finish().toString("hex");
 
-      await truffleAssert.reverts(
-        instance.decode_uint32.call(1, "0x" + encoded),
-        "ProtobufLib/decode_uint32 - highest 4 bytes must be 0"
-      );
+      const result = await instance.decode_uint32.call(1, "0x" + encoded);
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, false);
     });
 
     it("uint64", async () => {
@@ -188,7 +195,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_uint64.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -205,7 +213,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_uint64.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos.toNumber(), encoded.length / 2);
       assert.equal(val, v);
 
@@ -215,10 +224,9 @@ contract("TestFixture", async (accounts) => {
     it("uint64 too large", async () => {
       const instance = await TestFixture.deployed();
 
-      await truffleAssert.reverts(
-        instance.decode_uint64.call(1, "0x08ffffffffffffffffffff01"),
-        "ProtobufLib/decode_varint - uses more than MAX_VARINT_BYTES bytes"
-      );
+      const result = await instance.decode_uint64.call(1, "0x08ffffffffffffffffffff01");
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, false);
     });
 
     it("int64 max", async () => {
@@ -231,7 +239,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_int64.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -248,7 +257,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_int64.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -265,7 +275,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_sint32.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -282,7 +293,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_sint32.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -299,7 +311,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_sint64.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -316,7 +329,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_sint64.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -333,7 +347,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_bool.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, true);
 
@@ -359,7 +374,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_enum.call(3, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -376,7 +392,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_bits64.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -393,7 +410,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_fixed64.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -410,7 +428,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_sfixed64.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -427,7 +446,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_sfixed64.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -444,7 +464,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_bits32.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -461,7 +482,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_fixed32.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -478,7 +500,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_sfixed32.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -495,7 +518,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_sfixed32.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -512,7 +536,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_length_delimited.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, "0x" + v.toString("hex"));
 
@@ -529,7 +554,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_string.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, v);
 
@@ -546,7 +572,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_bytes.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, "0x" + v.toString("hex"));
 
@@ -569,7 +596,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_embedded_message.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, "0x" + EmbeddedMessage.encode(embeddedMessage).finish().toString("hex"));
 
@@ -586,7 +614,8 @@ contract("TestFixture", async (accounts) => {
       const encoded = Message.encode(message).finish().toString("hex");
 
       const result = await instance.decode_packed_repeated.call(1, "0x" + encoded);
-      const { 0: pos, 1: val } = result;
+      const { 0: success, 1: pos, 2: val } = result;
+      assert.equal(success, true);
       assert.equal(pos, encoded.length / 2);
       assert.equal(val, "0x" + encoded.slice(4));
 

--- a/test/TestFixture.js
+++ b/test/TestFixture.js
@@ -538,8 +538,8 @@ contract("TestFixture", async (accounts) => {
       const result = await instance.decode_length_delimited.call(1, "0x" + encoded);
       const { 0: success, 1: pos, 2: val } = result;
       assert.equal(success, true);
-      assert.equal(pos, encoded.length / 2);
-      assert.equal(val, "0x" + v.toString("hex"));
+      assert.equal(pos, 2);
+      assert.equal(val, encoded.length / 2 - 2);
 
       await instance.decode_length_delimited(1, "0x" + encoded);
     });
@@ -574,8 +574,8 @@ contract("TestFixture", async (accounts) => {
       const result = await instance.decode_bytes.call(1, "0x" + encoded);
       const { 0: success, 1: pos, 2: val } = result;
       assert.equal(success, true);
-      assert.equal(pos, encoded.length / 2);
-      assert.equal(val, "0x" + v.toString("hex"));
+      assert.equal(pos, 2);
+      assert.equal(val, encoded.length / 2 - 2);
 
       await instance.decode_bytes(1, "0x" + encoded);
     });
@@ -598,8 +598,8 @@ contract("TestFixture", async (accounts) => {
       const result = await instance.decode_embedded_message.call(1, "0x" + encoded);
       const { 0: success, 1: pos, 2: val } = result;
       assert.equal(success, true);
-      assert.equal(pos, encoded.length / 2);
-      assert.equal(val, "0x" + EmbeddedMessage.encode(embeddedMessage).finish().toString("hex"));
+      assert.equal(pos, 2);
+      assert.equal(val, encoded.length / 2 - 2);
 
       await instance.decode_embedded_message(1, "0x" + encoded);
     });
@@ -616,8 +616,8 @@ contract("TestFixture", async (accounts) => {
       const result = await instance.decode_packed_repeated.call(1, "0x" + encoded);
       const { 0: success, 1: pos, 2: val } = result;
       assert.equal(success, true);
-      assert.equal(pos, encoded.length / 2);
-      assert.equal(val, "0x" + encoded.slice(4));
+      assert.equal(pos, 2);
+      assert.equal(val, encoded.length / 2 - 2);
 
       await instance.decode_packed_repeated(1, "0x" + encoded);
     });


### PR DESCRIPTION
Use a success flag instead of reverting, to handle decoding of malformed data.